### PR TITLE
fix(pages): index chechando nome completo no input

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -9,6 +9,12 @@ export default function Home() {
 
 	function handleConnect(event) {
 		event.preventDefault();
+
+		if (nome.split(" ").length > 1) {
+			alert("Você deve informar seu nome completo.");
+			return;
+		}
+
 		setCookie(null, "nomeUsuario", nome, {
 			path: '/',
 			maxAge: 86400


### PR DESCRIPTION
Dá `split` com `" "`  e espera `length > 1` porque o esperado é que tenha pelo menos dois nomes (primeiro e sobrenome).